### PR TITLE
Update FindIt.cs

### DIFF
--- a/FindIt/FindIt.cs
+++ b/FindIt/FindIt.cs
@@ -127,6 +127,11 @@ namespace FindIt
                     searchBox = scrollPanel.parent.AddUIComponent<UISearchBox>();
                     searchBox.scrollPanel = scrollPanel;
                     searchBox.relativePosition = new Vector3(0, 0);
+                    searchBox.input.eventKeyDown += (component, eventParam) =>
+			        {
+				        if (eventParam.keycode != KeyCode.DownArrow && eventParam.keycode != KeyCode.UpArrow) return;
+				        searchBox.typeFilter.selectedIndex = Mathf.Clamp(searchBox.typeFilter.selectedIndex + (eventParam.keycode == KeyCode.DownArrow ? 1 : -1), 0, searchBox.typeFilter.items.Length);
+		        	};
                     searchBox.Search();
                 }
                 else


### PR DESCRIPTION
Quick addon to enable users to change the type filter dropdown using the arrow keys when the search input box is focused. I've used this as part of a private modification of the original FindIt for a long time and in can be a wonderful timesaver.