### PR TITLE
Extended Managers Library compatiblity

### DIFF
--- a/FindIt/AssetTagList.cs
+++ b/FindIt/AssetTagList.cs
@@ -447,7 +447,7 @@ namespace FindIt
             if (PropManager.exists && ((filter == UISearchBox.DropDownOptions.All) || (filter == UISearchBox.DropDownOptions.Prop) || (filter == UISearchBox.DropDownOptions.Decal)))
             {
                 // Use separate sub-class to control EML API type requirements via insantiation, so API file is not needed to be included with mod.
-                CountPropPrefabs counter = FindIt.isEMLEnabled ? new CountPropPrefabs() : new ECountPropPrefabs();
+                CountPropPrefabs counter = FindIt.isEMLEnabled ? new ECountPropPrefabs() : new CountPropPrefabs();
 
                 counter.Count(prefabInstanceCountDictionary);
             }

--- a/FindIt/AssetTagList.cs
+++ b/FindIt/AssetTagList.cs
@@ -15,6 +15,7 @@ using FindIt.GUI;
 using System.Reflection;
 using ColossalFramework.Globalization;
 using ColossalFramework.IO;
+using EManagersLib.API;
 
 namespace FindIt
 {
@@ -445,20 +446,10 @@ namespace FindIt
 
             if (PropManager.exists && ((filter == UISearchBox.DropDownOptions.All) || (filter == UISearchBox.DropDownOptions.Prop) || (filter == UISearchBox.DropDownOptions.Decal)))
             {
-                foreach (PropInstance prop in PropManager.instance.m_props.m_buffer)
-                {
-                    if ((PropInstance.Flags)prop.m_flags != PropInstance.Flags.None && (PropInstance.Flags)prop.m_flags != PropInstance.Flags.Deleted)
-                    {
-                        if (prefabInstanceCountDictionary.ContainsKey(prop.Info))
-                        {
-                            prefabInstanceCountDictionary[prop.Info] += 1;
-                        }
-                        else
-                        {
-                            prefabInstanceCountDictionary.Add(prop.Info, 1);
-                        }
-                    }
-                }
+                // Use separate sub-class to control EML API type requirements via insantiation, so API file is not needed to be included with mod.
+                CountPropPrefabs counter = FindIt.isEMLEnabled ? new CountPropPrefabs() : new ECountPropPrefabs();
+
+                counter.Count(prefabInstanceCountDictionary);
             }
 
             if (TreeManager.exists && ((filter == UISearchBox.DropDownOptions.All) || (filter == UISearchBox.DropDownOptions.Tree)))
@@ -767,5 +758,66 @@ namespace FindIt
             return time;
         }
 
+    }
+
+
+    /// <summary>
+    /// Class to count prop prefabs - without Extended Managers Library present.
+    /// </summary>
+    internal class CountPropPrefabs
+    {
+        /// <summary>
+        /// Counts each prop prefab loaded by game and adds to provided dictionary of prefab counts.
+        /// </summary>
+        /// <param name="prefabInstanceCountDictionary">Dictionary to add counts to</param>
+        internal virtual void Count(Dictionary<PrefabInfo, uint> prefabInstanceCountDictionary)
+        {
+            foreach (PropInstance prop in PropManager.instance.m_props.m_buffer)
+            {
+                if ((PropInstance.Flags)prop.m_flags != PropInstance.Flags.None && (PropInstance.Flags)prop.m_flags != PropInstance.Flags.Deleted)
+                {
+                    if (prefabInstanceCountDictionary.ContainsKey(prop.Info))
+                    {
+                        prefabInstanceCountDictionary[prop.Info] += 1;
+                    }
+                    else
+                    {
+                        prefabInstanceCountDictionary.Add(prop.Info, 1);
+                    }
+                }
+            }
+        }
+    }
+
+
+    /// <summary>
+    /// Class to count prop prefabs - with Extended Managers Library present.
+    /// All references to EML types are contained within this class, so if it is not instantiated then no EML binaries are needed.
+    /// When this class is instantiated, the EML API will need to be present in-game to avoid a TypeLoadError, but does not need to be bundled with this mod.
+    /// Checking for EML availablilty before instantiating this class means that no EML API binary needs to be distributed with this mod.
+    /// </summary>
+    internal class ECountPropPrefabs : CountPropPrefabs
+    {
+        /// <summary>
+        /// Counts each prop prefab loaded by game and adds to provided dictionary of prefab counts.
+        /// </summary>
+        /// <param name="prefabInstanceCountDictionary">Dictionary to add counts to</param>
+        internal override void Count(Dictionary<PrefabInfo, uint> prefabInstanceCountDictionary)
+        {
+            foreach (EPropInstance prop in EPropManager.m_props.m_buffer)
+            {
+                if ((EPropInstance.Flags)prop.m_flags != EPropInstance.Flags.None && (EPropInstance.Flags)prop.m_flags != EPropInstance.Flags.Deleted)
+                {
+                    if (prefabInstanceCountDictionary.ContainsKey(prop.Info))
+                    {
+                        prefabInstanceCountDictionary[prop.Info] += 1;
+                    }
+                    else
+                    {
+                        prefabInstanceCountDictionary.Add(prop.Info, 1);
+                    }
+                }
+            }
+        }
     }
 }

--- a/FindIt/FindIt.cs
+++ b/FindIt/FindIt.cs
@@ -30,6 +30,7 @@ namespace FindIt
         public static bool isOWTTEnabled = false; // One-Way Train Tracks mod enabled?
         public static bool isMeshInfoEnabled = false; // MeshInfo mod enabled?
         public static bool isYATEnabled = false; // Yet Another Toolbar enabled?
+        public static bool isEMLEnabled = false; // Extended Managers Library enabled?
 
 
         public bool firstVisibleFlag = false;
@@ -339,6 +340,7 @@ namespace FindIt
             isMeshInfoEnabled = enabledMods.Contains("meshinfo");
             isNTCPEnabled = enabledMods.Contains("nonterrainconformingprops");
             isYATEnabled = enabledMods.Contains("yetanothertoolbar");
+            isEMLEnabled = enabledMods.Contains("emanagerslib");
         }
 
         public static UITextureAtlas LoadResources()

--- a/FindIt/FindIt.csproj
+++ b/FindIt/FindIt.csproj
@@ -49,6 +49,10 @@
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="EManagersLib.API, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\workshop\content\255710\2607980391\EManagersLib.API.dll</HintPath>
+    </Reference>
     <Reference Include="ICities">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ICities.dll</HintPath>
       <Private>False</Private>

--- a/FindIt/Translations/ru.xml
+++ b/FindIt/Translations/ru.xml
@@ -230,8 +230,5 @@
     <Translation ID="FIF_SET_DISTP" String="Используйте этот параметр, чтобы уменьшить задержку пользовательского интерфейса при вводе текста в поле поиска" />
     <Translation ID="FIF_SET_STAB" String="Показать вкладки поиска" />
     <Translation ID="FIF_STAB_NTAB" String="Новая вкладка" />
- 
   </Translations>
 </Language>
- 
-RAW Paste Data


### PR DESCRIPTION
Implements compatibility with Extended Managers Library's extended prop limit.

Requires a current reference to EManagersLib.API.dll to build, but does **NOT** require it to be bundled with Find It, or even present at runtime (this change uses instantiation control to avoid EML references when EML is not available).